### PR TITLE
Bugfix: gettimeofday() does not return the correct amount if microsec…

### DIFF
--- a/parity.runtime/time.c
+++ b/parity.runtime/time.c
@@ -34,7 +34,7 @@ int gettimeofday(struct timeval *tv, void* unused)
     ftime(&tb);
 
     tv->tv_sec  = (long)tb.time;
-    tv->tv_usec = (long)tb.millitm;
+    tv->tv_usec = (long)tb.millitm * 1000L;
     return(0);
 }
 


### PR DESCRIPTION
Bugfix: gettimeofday() does not return the correct amount if microseconds

tv_usec was filled with a milliseconds value, not microseconds.
See man pages. In my use case, the amount of milliseconds was always zero:

  struct timeval tv = {};

  gettimeofday( &tv, NULL);

  time_t unix_timestamp = tv.tv_sec;
  int milliseconds = tv.tv_usec / 1000;

  std::cout <<  unix_timestamp << "." << milliseconds << std::endl;