### PR TITLE
parity: implemented option --help

### DIFF
--- a/parity.options/Internal.cpp
+++ b/parity.options/Internal.cpp
@@ -30,6 +30,34 @@ namespace parity
 {
 	namespace options
 	{
+		static const char *helpText =
+			"supports many of the common gcc/g++ options and\n"
+			"translates them to the host compiler ones as far as possible.\n"
+			"\n"
+			"everything that can't be mapped accordingly can be forwarded to the\n"
+			"compiler or the linker via the -X and -Y options, respectively.\n"
+			"\n"
+			PACKAGE_NAME " itself has the following options:\n"
+            "\n"
+            "    -v              show " PACKAGE_NAME "'s configuration\n"
+            "    -dbg level      turn on debugging (levels 1 - 4 where 4 is verbose)\n"
+            "    -ctxdump        dump " PACKAGE_NAME "'s internal state\n"
+            "    -cfg value      set a config string e. g. -cfg 'KeepTemporary=1'\n"
+            "                    look for configuration.txt.bz2 in your doc path\n"
+            "                    (most probably \$EPREFIX/usr/share/doc/parity*)\n"
+            "    -X value        forward value to the compiler\n"
+            "    -Y value        forward value to the linker\n"
+            "\n"
+            "to show your toolchain's help, forward the help-request:\n"
+            "\n"
+            "    compiler help:  g++ -X /?\n"
+            "    linker help:    g++ -Y /?\n"
+            "\n"
+            "you probably also may want to have a look at " PACKAGE_NAME "'s man page:\n"
+            "\n"
+            "    man " PACKAGE_NAME "\n"
+			;
+
 		bool setDebugLevel(const char* option, const char* argument, bool& used)
 		{
 			if(!argument)
@@ -86,6 +114,18 @@ namespace parity
 		{
 			bool optused = false;
 			return setLinkerPassthrough("-Y", option, optused);
+		}
+
+		bool showParityHelp(const char* OPT_UNUSED(option), const char* OPT_UNUSED(argument), bool& OPT_UNUSED(used))
+		{
+			std::cout << PACKAGE_NAME << " " << PACKAGE_VERSION << " " << "(" << __DATE__ << ") ";
+			std::cout << helpText << std::endl;
+			exit(0);
+
+			#ifndef _WIN32
+			/* never reached (this is there for some gcc versions)! */
+			return false;
+			#endif
 		}
 
 		bool showParityVersion(const char* OPT_UNUSED(option), const char* OPT_UNUSED(argument), bool& OPT_UNUSED(used))

--- a/parity.options/Internal.h
+++ b/parity.options/Internal.h
@@ -37,6 +37,7 @@ namespace parity
 		bool setCompilerPassthrough(const char* option, const char* argument, bool& used);
 		bool setUnhandledSourceFilePassthrough(const char* option, const char* argument, bool& used);
 		bool setUnhandledObjectFilePassthrough(const char* option, const char* argument, bool& used);
+		bool showParityHelp(const char* option, const char* argument, bool& used);
 		bool showParityVersion(const char* option, const char* argument, bool& used);
 		bool showParityConfig(const char* option, const char* argument, bool& used);
 		bool printProperty(const char* option, const char* argument, bool& used);

--- a/parity.options/TableGnuGcc.cpp
+++ b/parity.options/TableGnuGcc.cpp
@@ -37,6 +37,7 @@ namespace parity
 			//
 			// parity internal command line switches.
 			//
+			{ "--help"		,showParityHelp				},
 			{ "-dbg"		,setDebugLevel				},
 			{ "-X"			,setCompilerPassthrough		},
 			{ "-Y"			,setLinkerPassthrough		},	// GCC knows -Xlinker here.

--- a/parity.tasks/CollectorOther.cpp
+++ b/parity.tasks/CollectorOther.cpp
@@ -390,6 +390,20 @@ namespace parity
 					exit(1);
 				}
 			}
+
+			//
+			// to be able to forward a --help request we need to supply a dummy source file.
+			// otherwise one would have to write g++ -X /? dummy.c.
+			//
+			// TODO:
+			// The mechanism works, but after showing the respective help parity
+			// reports an error and I do not know how to avoid this.
+			//
+			if(context.getSources().empty() && !context.getCompilerPassThrough().empty())
+			{
+				context.getSources()[parity::utils::Path("dummy.c")] = utils::LanguageC;
+			}
+
 			//
 			// First task is the Dependency Tracker (in background)
 			// With the GNU Backend, dependency tracking is a real side


### PR DESCRIPTION
This also led to an attempt to forward compiler or linker options
(-X/-Y) without specifying a source file, so that one can request the
toolchain's help by issuing 'g++ -X /?' or 'g++ -Y /?'.

The mechanism works, but after showing the respective help parity
reports an error and I do not know how to avoid this.

Change-Id: I1954d6a23501e936378d60bb59bb2c33db696a88